### PR TITLE
Catch all exceptions thrown from historic requests

### DIFF
--- a/src/async_hta_service.hpp
+++ b/src/async_hta_service.hpp
@@ -371,7 +371,18 @@ public:
     void async_read(const std::string id, const metricq::HistoryRequest& content, Handler handler)
     {
         asio::post(get_strand(id), [this, id, content, handler = std::move(handler)]() mutable {
-            this->read_(id, content, std::move(handler));
+            try
+            {
+                this->read_(id, content, std::move(handler));
+            }
+            catch (std::exception& e)
+            {
+                Log::error()
+                    << "An error occured during the handling of a history request for metricq '"
+                    << id << "': " << e.what();
+
+                // TODO actually notify the sender of the request that something went wrong
+            }
         });
     }
 


### PR DESCRIPTION
We should not let the database crash from something that happens in read.
Maybe this is the wrong way and we should instead sanitize the god damn
"user" input, but nobody ain't got time for tis.

Fixes #7 