### PR TITLE
Allows to configure logging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
-project(metricq-db-hta)
+cmake_minimum_required(VERSION 3.13)
 
-cmake_minimum_required(VERSION 3.8)
+project(metricq-db-hta)
 
 include(cmake/DefaultBuildType.cmake)
 include(cmake/GitSubmoduleUpdate.cmake)

--- a/src/async_hta_service.hpp
+++ b/src/async_hta_service.hpp
@@ -80,8 +80,8 @@ struct LoggingConfig
         try
         {
             auto logging = config.at("logging");
-            nan_values = logging.value<bool>("nan_values", true);
-            non_monotonic_values = logging.value<bool>("non_monotonic_values", true);
+            nan_values = logging.value<bool>("nan_values", nan_values);
+            non_monotonic_values = logging.value<bool>("non_monotonic_values", non_monotonic_values);
         }
         catch (std::exception& e)
         {

--- a/src/async_hta_service.hpp
+++ b/src/async_hta_service.hpp
@@ -75,13 +75,13 @@ struct LoggingConfig
 {
     LoggingConfig() = default;
 
-    LoggingConfig(metricq::json& config)
+    LoggingConfig(const metricq::json& config)
     {
         try
         {
             auto logging = config.at("logging");
-            nan_values = logging.value<bool>("nan_values", nan_values);
-            non_monotonic_values = logging.value<bool>("non_monotonic_values", non_monotonic_values);
+            nan_values = logging.value("nan_values", nan_values);
+            non_monotonic_values = logging.value("non_monotonic_values", non_monotonic_values);
         }
         catch (std::exception& e)
         {
@@ -159,7 +159,7 @@ public:
             }
         }
 
-        logging_ = LoggingConfig(config);
+        logging_ = LoggingConfig{ config };
 
         if (!pool_)
         {
@@ -261,7 +261,6 @@ private:
                 skip_non_monotonic++;
                 continue;
             }
-            // TODO make this configurable
             if (std::isnan(tv.htv.value))
             {
                 skip_nan++;


### PR DESCRIPTION
The message for nan-values and non-monotonic values can now be toggled  via config.

This adds a new section in the db config:
```
{
  logging: {
    nan_values: false,
    non_monotonic_values: true
  }
}
```

Fixes #13 